### PR TITLE
FMRF-18 Keycloak reverse proxy update config

### DIFF
--- a/apps/fmr/models/file-upload.js
+++ b/apps/fmr/models/file-upload.js
@@ -59,7 +59,8 @@ module.exports = class UploadModel extends Model {
     })
       .then(result => {
         try {
-          console.log('FILE URL: ', result.url.replace('/file/', '/file/generate-link/').split('?')[0])
+          // eslint-disable-next-line no-console
+          console.log('FILE URL: ', result.url.replace('/file/', '/file/generate-link/').split('?')[0]);
           this.set({
             url: result.url.replace('/file/', '/file/generate-link/').split('?')[0]
           });

--- a/apps/fmr/models/file-upload.js
+++ b/apps/fmr/models/file-upload.js
@@ -59,8 +59,6 @@ module.exports = class UploadModel extends Model {
     })
       .then(result => {
         try {
-          // eslint-disable-next-line no-console
-          console.log('FILE URL: ', result.url.replace('/file/', '/file/generate-link/').split('?')[0]);
           this.set({
             url: result.url.replace('/file/', '/file/generate-link/').split('?')[0]
           });

--- a/apps/fmr/models/file-upload.js
+++ b/apps/fmr/models/file-upload.js
@@ -59,6 +59,7 @@ module.exports = class UploadModel extends Model {
     })
       .then(result => {
         try {
+          console.log('FILE URL: ', result.url.replace('/file/', '/file/generate-link/').split('?')[0])
           this.set({
             url: result.url.replace('/file/', '/file/generate-link/').split('?')[0]
           });

--- a/apps/fmr/views/content/en/file-requirements.md
+++ b/apps/fmr/views/content/en/file-requirements.md
@@ -1,4 +1,4 @@
 The file must be:
 
-- a JPG, PNG or GIF file
+- a JPG, PNG, GIF, JPEG or PDF file
 - smaller than 20MB

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -167,6 +167,10 @@ spec:
                 secretKeyRef:
                   name: keycloak-client
                   key: id
+            - name: PROXY_LISTEN
+              value: 127.0.0.1:3001
+            - name: PROXY_UPSTREAM_URL
+              value: "https://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
@@ -188,8 +192,6 @@ spec:
               value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/fmr-notprod
             {{ end }}
           args:
-            - --listen=:3001
-            - --upstream-url=http://127.0.0.1:3000
             # URls that you wish to protect.
             - --resources=uri=/*
             - --enable-default-deny=false
@@ -197,6 +199,8 @@ spec:
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
+            - --tls-cert=/certs/tls.crt
+            - --tls-private-key=/certs/tls.key
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -167,10 +167,6 @@ spec:
                 secretKeyRef:
                   name: keycloak-client
                   key: id
-            - name: PROXY_LISTEN
-              value: 127.0.0.1:3001
-            - name: PROXY_UPSTREAM_URL
-              value: "https://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk
@@ -192,6 +188,8 @@ spec:
               value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/fmr-notprod
             {{ end }}
           args:
+            - --listen=:3001
+            - --upstream-url=https://127.0.0.1:3000
             # URls that you wish to protect.
             - --resources=uri=/*
             - --tls-cert=/certs/tls.crt

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -197,8 +197,6 @@ spec:
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
-            - --tls-cert=/certs/tls.crt
-            - --tls-private-key=/certs/tls.key
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -189,18 +189,14 @@ spec:
             {{ end }}
           args:
             - --listen=:3001
-            - --upstream-url=https://127.0.0.1:3000
+            - --upstream-url=http://127.0.0.1:3000
             # URls that you wish to protect.
             - --resources=uri=/*
-            - --tls-cert=/certs/tls.crt
-            - --tls-private-key=/certs/tls.key
             - --enable-default-deny=false
-            - --http-only-cookie=true
             - --enable-security-filter=true
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
-            - --tls-min-version=tlsv1.2
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -170,7 +170,7 @@ spec:
             - name: PROXY_LISTEN
               value: 127.0.0.1:3001
             - name: PROXY_UPSTREAM_URL
-              value: "https://127.0.0.1:3000"
+              value: "http://127.0.0.1:3000"
             - name: PROXY_REDIRECTION_URL
             {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
               value: https://fv.prod.{{ .APP_NAME }}.homeoffice.gov.uk

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -197,6 +197,8 @@ spec:
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
+            - --tls-cert=/certs/tls.crt
+            - --tls-private-key=/certs/tls.key
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -199,8 +199,6 @@ spec:
             - --enable-request-id=true
             - --enable-logging=true
             - --enable-json-logging=true
-            - --tls-cert=/certs/tls.crt
-            - --tls-private-key=/certs/tls.key
             {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - --verbose=true
             {{ end }}


### PR DESCRIPTION
## What? 

Updated Keycloak-proxy configuration to allow file uploads.

Removed references to TLS certs and TLS minimum version. 

## Why? 

These config values were stopping the proxy from accepting requests from nginx.

## Anything Else? (optional)

Added a couple of extra options for allowed file types to the upload page markdown (PDF and JPEG)

## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
