### PR TITLE
FMRF-5: Add missing network policy for fmr external ingress

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -371,7 +371,7 @@ steps:
     environment:
         IMAGE_NAME: sas/fmr:${DRONE_COMMIT_SHA}
         SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
-        SEVERITY: UNKOWN,LOW,MEDIUM,HIGH,CRITICAL
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: false
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml
@@ -384,7 +384,7 @@ steps:
     pull: always
     environment:
         IMAGE_NAME: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
-        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+        SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: false
         IGNORE_UNFIXED: false
         ALLOW_CVE_LIST_FILE: hof-services-config/infrastructure/trivy/.trivyignore.yaml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -36,6 +36,7 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
+  $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
   $kd -f kube/redis  -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -181,16 +181,6 @@ spec:
             {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
               value: https://fv-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
             {{ end }}
-            - name: PROXY_DISCOVERY_URL
-            {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-              value: https://acp-sso.prod.acp.homeoffice.gov.uk/realms/fmr
-            {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
-              value: https://acp-sso.prod.acp.homeoffice.gov.uk/realms/fmr
-            {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
-              value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/fmr-notprod
-            {{ else if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-              value: https://acp-sso.notprod.acp.homeoffice.gov.uk/realms/fmr-notprod
-            {{ end }}
           args:
             # URls that you wish to protect.
             - --resources=uri=/*

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -136,10 +136,8 @@ spec:
               value: "no"
             - name: ALLOW_GENERATE_LINK_ROUTE
               value: "yes"
-            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
             - name: DEBUG
               value: "*"
-            {{ end }}
           securityContext:
             runAsNonRoot: true
 


### PR DESCRIPTION
## What? 

* We are seeing 503 gateway page as the ingress is unable to communicate with the backend services
* I have manually added it to test and is working. 
* we need it to be part of pipeline to prevent issues in future
* Add DEBUG in Filevault container in all the envs to help debug issues
* Trivy Cron step is failing due to type error. 

## Why?
* Performance testers unable to access the fmr external ingress of stage env.
* We found the reason to be missing network policies.
* As these network policies plays crucial part in  allowing us to control the traffic flow
 
## How? 
I have now added to deploy.sh scripts. 
Conditional statement restricting DEBUG to branch env is removed to ensure we can do debugging on all the envs
Trivy Severity type error has been updated.

## Testing?
Manually tested. Now these changes will be automatically be picked by CI pipeline

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
