### PR TITLE
FMRF-5: Update production URL

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ environment:
   STG_ENV: sas-fmr-stg
   UAT_ENV: sas-fmr-uat
   BRANCH_ENV: sas-fmr-branch
-  PRODUCTION_URL: www.request-reference-evisa.homeoffice.gov.uk
+  PRODUCTION_URL: request-reference-evisa.homeoffice.gov.uk
   IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/fmr
   GIT_REPO: UKHomeOffice/evisa-find-my-reference


### PR DESCRIPTION
## What? 

* Business requested us to use redirected url without www.
* We have added force redirect to url without www.

## Why? 

Policy admissions have been added on 8th October 2024.
We have added and updated ingresses, certs and secrets.
We have added permanent redirect 301 to the ingress url

## How? 

Update the production url  without www. in drone.
Run the build on production to apply these changes.

## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
