### PR TITLE
FMRF-56: Preventing search engines from indexing all pages

### DIFF
--- a/.devcontainer/devcontainer.env.sample
+++ b/.devcontainer/devcontainer.env.sample
@@ -50,9 +50,12 @@ REDIS_HOST=hof-redis
 #KEYCLOAK_CLIENT_ID=
 #KEYCLOAK_SECRET=
 
-#Gov.uk Notify
+# Gov.uk Notify
 #NOTIFY_KEY=
 #CASEWORKER_EMAIL=
 #BUSINESS_CONFIRMATION_TEMPLATE_ID=
 #USER_CONFIRMATION_TEMPLATE_ID=
 EMAIL_REPLY_TO_ID=
+
+# Prevent all pages from being indexed by search engines
+DISALLOW_INDEXING="true"

--- a/.drone.yml
+++ b/.drone.yml
@@ -94,7 +94,7 @@ steps:
         memory: 1024Mi
     environment:
       IMAGE_NAME: node:20.17.0-alpine3.20@sha256:2cc3d19887bfea8bf52574716d5f16d4668e35158de866099711ddfb2b16b6e0
-      SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+      SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
       SEVERITY: MEDIUM,HIGH,CRITICAL  --dependency-tree
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: false
@@ -370,7 +370,7 @@ steps:
     pull: always
     environment:
         IMAGE_NAME: sas/fmr:${DRONE_COMMIT_SHA}
-        SERVICE_URL: https://acp-trivy.acp-trivy.svc.cluster.local:443
+        SERVICE_URL: https://acp-trivy-helm.acp-trivy.svc.cluster.local:443
         SEVERITY: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL --dependency-tree
         FAIL_ON_DETECTION: false
         IGNORE_UNFIXED: false

--- a/apps/fmr/index.js
+++ b/apps/fmr/index.js
@@ -3,107 +3,117 @@ const Summary = hof.components.summary;
 const SaveDocument = require('./behaviours/save-document');
 const RemoveDocument = require('./behaviours/remove-document');
 const submitRequest = require('./behaviours/submit-request');
+const { disallowIndexing } = require('../../config');
+
+const steps = {
+  '/': {
+    next: '/identity',
+    fields: [],
+    template: 'start',
+    sidepanel: true,
+    fullwidth: true,
+    isNeedHelpHidden: true
+  },
+  '/identity': {
+    next: '/name',
+    fields: ['identity'],
+    forks: [
+      {
+        target: '/identity-reason',
+        condition: {
+          field: 'identity',
+          value: 'no'
+        }
+      }
+    ],
+    backLink: ' ' // workaround to show Back link to the root of the app
+  },
+  '/identity-reason': {
+    next: '/name',
+    fields: ['identity-reason']
+  },
+  '/name': {
+    next: '/sex',
+    fields: ['given-names', 'surname']
+  },
+  '/sex': {
+    next: '/nationality',
+    fields: ['sex']
+  },
+  '/nationality': {
+    next: '/date-birth',
+    fields: ['country-of-nationality']
+  },
+  '/date-birth': {
+    next: '/upload-photo',
+    fields: ['dob']
+  },
+  '/upload-photo': {
+    next: '/any-other-information',
+    behaviours: [SaveDocument('identity-documents', 'file-upload'), RemoveDocument('identity-documents')],
+    fields: ['file-upload']
+  },
+  '/any-other-information': {
+    next: '/contact',
+    fields: ['anything-else']
+  },
+  '/contact': {
+    next: '/someone-else',
+    fields: [
+      'how-to-contact-you',
+      'email',
+      'address-line-1',
+      'address-line-2',
+      'town-or-city',
+      'county',
+      'postcode'
+    ]
+  },
+  '/someone-else': {
+    next: '/check-answers',
+    fields: ['someone-else'],
+    forks: [
+      {
+        target: '/someone-else-details',
+        condition: {
+          field: 'someone-else',
+          value: 'yes'
+        }
+      }
+    ]
+  },
+  '/someone-else-details': {
+    next: '/check-answers',
+    fields: [
+      'someone-else-name',
+      'someone-else-email',
+      'someone-else-type'
+    ]
+  },
+  '/check-answers': {
+    behaviours: [Summary, submitRequest],
+    sections: require('./sections/summary-data-sections'),
+    template: 'summary',
+    next: '/request-sent'
+  },
+  '/request-sent': {
+    clearSession: true,
+    backLink: false,
+    isNeedHelpHidden: true
+  }
+};
+
+const pages = {};
+
+if (disallowIndexing) {
+  pages['/robots.txt'] = 'static/robots';
+}
 
 module.exports = {
   name: 'fmr',
   baseUrl: '/',
   params: '/:action?/:id?/:edit?',
   confirmStep: '/check-answers',
-  steps: {
-    '/': {
-      next: '/identity',
-      fields: [],
-      template: 'start',
-      sidepanel: true,
-      fullwidth: true,
-      isNeedHelpHidden: true
-    },
-    '/identity': {
-      next: '/name',
-      fields: ['identity'],
-      forks: [
-        {
-          target: '/identity-reason',
-          condition: {
-            field: 'identity',
-            value: 'no'
-          }
-        }
-      ],
-      backLink: ' ' // workaround to show Back link to the root of the app
-    },
-    '/identity-reason': {
-      next: '/name',
-      fields: ['identity-reason']
-    },
-    '/name': {
-      next: '/sex',
-      fields: ['given-names', 'surname']
-    },
-    '/sex': {
-      next: '/nationality',
-      fields: ['sex']
-    },
-    '/nationality': {
-      next: '/date-birth',
-      fields: ['country-of-nationality']
-    },
-    '/date-birth': {
-      next: '/upload-photo',
-      fields: ['dob']
-    },
-    '/upload-photo': {
-      next: '/any-other-information',
-      behaviours: [SaveDocument('identity-documents', 'file-upload'), RemoveDocument('identity-documents')],
-      fields: ['file-upload']
-    },
-    '/any-other-information': {
-      next: '/contact',
-      fields: ['anything-else']
-    },
-    '/contact': {
-      next: '/someone-else',
-      fields: [
-        'how-to-contact-you',
-        'email',
-        'address-line-1',
-        'address-line-2',
-        'town-or-city',
-        'county',
-        'postcode'
-      ]
-    },
-    '/someone-else': {
-      next: '/check-answers',
-      fields: ['someone-else'],
-      forks: [
-        {
-          target: '/someone-else-details',
-          condition: {
-            field: 'someone-else',
-            value: 'yes'
-          }
-        }
-      ]
-    },
-    '/someone-else-details': {
-      next: '/check-answers',
-      fields: [
-        'someone-else-name',
-        'someone-else-email',
-        'someone-else-type'
-      ]
-    },
-    '/check-answers': {
-      behaviours: [Summary, submitRequest],
-      sections: require('./sections/summary-data-sections'),
-      template: 'summary',
-      next: '/request-sent'
-    },
-    '/request-sent': {
-      clearSession: true,
-      backLink: false,
-      isNeedHelpHidden: true
-    }
-  }
+  steps: steps,
+  pages: pages
 };

--- a/apps/fmr/translations/src/en/journey.json
+++ b/apps/fmr/translations/src/en/journey.json
@@ -1,6 +1,6 @@
 {
-  "header": "Request your reference number to get access to your eVisa",
-  "serviceName": "Request your reference number to get access to your eVisa",
+  "header": "Request your reference number or book a video appointment to get access to your eVisa",
+  "serviceName": "Request your reference number or book a video appointment to get access to your eVisa",
   "error": "Error",
   "uploading": "Uploading your photo..."
 }

--- a/apps/fmr/views/content/en/need-help.md
+++ b/apps/fmr/views/content/en/need-help.md
@@ -1,1 +1,0 @@
-Need help? [Contact us](https://www.gov.uk/contact-ukvi-inside-outside-uk)

--- a/apps/fmr/views/layout.html
+++ b/apps/fmr/views/layout.html
@@ -1,6 +1,11 @@
 {{<govuk-template}}
   {{$head}}
     {{> partials-head}}
+    
+    {{#disallowIndexing}}
+      {{> partials-disallow-indexing}}
+    {{/disallowIndexing}}
+    
   {{/head}}
   {{$pageTitle}}
     {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}} {{title}} &ndash; {{#t}}journey.serviceName{{/t}} &ndash; GOV.UK

--- a/apps/fmr/views/partials/disallow-indexing.html
+++ b/apps/fmr/views/partials/disallow-indexing.html
@@ -1,0 +1,1 @@
+<meta name="robots" content="noindex">

--- a/apps/fmr/views/partials/need-help.html
+++ b/apps/fmr/views/partials/need-help.html
@@ -1,5 +1,5 @@
 {{^options.isNeedHelpHidden}}
     <div class="govuk-inset-text blue-inset govuk-!-margin-top-0 govuk-!-margin-bottom-8">
-        {{#markdown}}need-help{{/markdown}}
+        Need help? <a href="https://www.gov.uk/contact-ukvi-inside-outside-uk">Contact us</a>
     </div>
 {{/options.isNeedHelpHidden}}

--- a/apps/fmr/views/static/robots.html
+++ b/apps/fmr/views/static/robots.html
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -199,3 +199,8 @@ pre.looped-records {
 .govuk-fieldset__heading{
   font-family: "GDS Transport", arial, sans-serif;
 }
+
+.govuk-radios fieldset {
+  width: auto;
+  max-width: 100%;
+}

--- a/config.js
+++ b/config.js
@@ -54,5 +54,6 @@ module.exports = {
     clientId: process.env.KEYCLOAK_CLIENT_ID,
     secret: process.env.KEYCLOAK_SECRET
   },
-  uniqueRefNumberPrefix: 'FMR-'
+  uniqueRefNumberPrefix: 'FMR-',
+  disallowIndexing: process.env.DISALLOW_INDEXING === 'true'
 };

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Request your reference number to get access to your eVisa",
+  "appName": "Request your reference number or book a video appointment to get access to your eVisa",
   "theme": "govUK",
   "behaviours": [
     "hof/components/clear-session"

--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -114,6 +114,9 @@ spec:
             - name: DEBUG
               value: "*"
             {{ end }}
+            # Preventing search engines from indexing all pages
+            - name: DISALLOW_INDEXING
+              value: "true"
           {{ if not (eq .KUBE_NAMESPACE .BRANCH_ENV) }}
           livenessProbe:
             httpGet:

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const app = hof(settings);
 
 app.use((req, res, next) => {
   res.locals.htmlLang = 'en';
+  res.locals.disallowIndexing = config.disallowIndexing;
   next();
 });
 


### PR DESCRIPTION
## What? 
Prevent all pages from being indexed by search engines
[FMRF-56](https://collaboration.homeoffice.gov.uk/jira/browse/FMRF-56) - Prevent all FMR pages from being indexed by search engines

## Why? 
Requested by stakeholders so that pages from this form do not appear in search results
## How? 
- added environment variable DISALLOW_INDEXING
- if DISALLOW_INDEXING is set to true, this will add `robots.txt` file and meta tag `<meta name="robots" content="noindex">`
## Testing?
## Screenshots (optional)
## Anything Else? (optional)

- [FMRF-57](https://collaboration.homeoffice.gov.uk/jira/browse/FMRF-57) - TLF - FMR - Page is shifted to the right when radio button is selected to input more info
- Updated service name on the header and title tag
- Updated URL to Trivy service
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
