### PR TITLE
Changed font weights for field labels where they appeared in bold;

### DIFF
--- a/apps/fmr/fields/index.js
+++ b/apps/fmr/fields/index.js
@@ -52,14 +52,12 @@ module.exports = {
   'given-names': {
     mixin: 'input-text',
     validate: [validateText],
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    labelClassName: 'govuk-label--s'
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   surname: {
     mixin: 'input-text',
     validate: ['required', validateText],
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    labelClassName: 'govuk-label--s'
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   sex: {
     mixin: 'radio-group',
@@ -190,8 +188,7 @@ module.exports = {
   'someone-else-name': {
     mixin: 'input-text',
     validate: ['required', validateText],
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    labelClassName: 'govuk-label--s'
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'someone-else-email': {
     mixin: 'input-text',
@@ -200,8 +197,7 @@ module.exports = {
       'email',
       { type: 'maxlength', arguments: 254 }
     ],
-    className: ['govuk-input', 'govuk-!-width-two-thirds'],
-    labelClassName: 'govuk-label--s'
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'someone-else-type': {
     mixin: 'radio-group',


### PR DESCRIPTION
## What? 
[FMRF-61](https://collaboration.homeoffice.gov.uk/jira/browse/FMRF-61) - Font weight changes for field labels
## Why? 
UCD provided feedback on the form, requesting changes to the labels appearance  - font weights have been changed where they appear in bold.
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
