### PR TITLE
FMRF-76: Removal of screens

### DIFF
--- a/apps/fmr/behaviours/submit-request.js
+++ b/apps/fmr/behaviours/submit-request.js
@@ -52,9 +52,6 @@ module.exports = superclass => class extends superclass {
         given_names: req.sessionModel.get('given-names') ?
           req.sessionModel.get('given-names') : '',
         surname: req.sessionModel.get('surname'),
-        identity: getLabel('identity', req.sessionModel.get('identity')),
-        has_identity_reason: req.sessionModel.get('identity') === 'no' ? 'yes' : 'no',
-        identity_reason: req.sessionModel.get('identity') === 'no' ? req.sessionModel.get('identity-reason') : '',
         date_of_birth: formatDate(req.sessionModel.get('dob')),
         nationality: req.sessionModel.get('country-of-nationality'),
         sex: getLabel('sex', req.sessionModel.get('sex')),

--- a/apps/fmr/fields/index.js
+++ b/apps/fmr/fields/index.js
@@ -22,33 +22,6 @@ function validateText(value) {
 }
 
 module.exports = {
-  identity: {
-    isPageHeading: true,
-    mixin: 'radio-group',
-    validate: ['required'],
-    options: [
-      {
-        value: 'yes'
-      },
-      {
-        value: 'no'
-      }
-    ],
-    className: ['govuk-radios', 'govuk-radios--inline'],
-    legend: {
-      className: 'govuk-!-margin-bottom-6'
-    }
-  },
-  'identity-reason': {
-    isPageHeading: true,
-    mixin: 'textarea',
-    validate: [
-      'required',
-      { type: 'maxlength', arguments: 500 }
-    ],
-    attributes: [{ attribute: 'rows', value: 5 }],
-    labelClassName: 'govuk-!-margin-bottom-6'
-  },
   'given-names': {
     mixin: 'input-text',
     validate: [validateText],

--- a/apps/fmr/index.js
+++ b/apps/fmr/index.js
@@ -7,31 +7,11 @@ const { disallowIndexing } = require('../../config');
 
 const steps = {
   '/': {
-    next: '/identity',
+    next: '/name',
     fields: [],
     template: 'start',
     sidepanel: true,
     fullwidth: true
-  },
-  '/identity': {
-    next: '/name',
-    fields: ['identity'],
-    forks: [
-      {
-        target: '/identity-reason',
-        condition: {
-          field: 'identity',
-          value: 'no'
-        }
-      }
-    ],
-    showNeedHelp: true,
-    backLink: ' ' // workaround to show Back link to the root of the app
-  },
-  '/identity-reason': {
-    next: '/name',
-    fields: ['identity-reason'],
-    showNeedHelp: true
   },
   '/name': {
     next: '/sex',

--- a/apps/fmr/sections/summary-data-sections.js
+++ b/apps/fmr/sections/summary-data-sections.js
@@ -4,14 +4,6 @@ module.exports = {
   'personal-details': {
     steps: [
       {
-        step: '/identity',
-        field: 'identity'
-      },
-      {
-        step: '/identity-reason',
-        field: 'identity-reason'
-      },
-      {
         step: '/name',
         field: 'given-names'
       },

--- a/apps/fmr/translations/src/en/fields.json
+++ b/apps/fmr/translations/src/en/fields.json
@@ -1,19 +1,4 @@
 {
-    "identity": {
-        "legend": "Do you have a valid passport?",
-        "hint": "To be valid, the passport expiry date must be in the future.",
-        "options": {
-            "yes": {
-                "label": "Yes"
-            },
-            "no": {
-                "label": "No"
-            }
-        }
-    },
-    "identity-reason": {
-        "label": "Tell us why you do not have a valid passport"
-    },
     "given-names": {
         "label": "Given names",
         "hint": "Your first and middle names"

--- a/apps/fmr/translations/src/en/pages.json
+++ b/apps/fmr/translations/src/en/pages.json
@@ -52,12 +52,6 @@
       }
     },
     "fields": {
-      "identity": {
-        "label": "Have passport"
-      },
-      "identity-reason": {
-        "label": "Reason why you do not have a valid passport"
-      },
       "given-names": {
         "label": "Your name"
       },

--- a/apps/fmr/translations/src/en/validation.json
+++ b/apps/fmr/translations/src/en/validation.json
@@ -1,11 +1,4 @@
 {
-    "identity": {
-        "required": "Select if you have a valid passport"
-    },
-    "identity-reason": {
-        "required": "Enter a reason why you do not have a valid passport",
-        "maxlength": "You have exceeded the 500 character limit"
-    },
     "given-names": {
         "validateText": "Given names must only include letters a to z, spaces, hyphens and apostrophes"
     },


### PR DESCRIPTION
## What? 
Removed initial two form pages and updated following landing page

## Why? 
https://collaboration.homeoffice.gov.uk/jira/browse/FMRF-76

## How? 
- set /name as initial form page following landing page; removed /identity and /identity-reason paths (index.js)
- removed fields for /identity and /identity-reason pages (...fields/index.js; fields.json; pages.json)
- removed validation for /identity and /identity-reason (validation.json)
- removed data properties for /identity and /identity-reason (submit-request.js)
- removed summary-data-sections for /identity and /identity-reason (summary-data-sections.js)
- minor formatting (package.json)
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
