### PR TITLE
FMRF-79: removing reference to EEC and maintain consistency between a…

### DIFF
--- a/apps/fmr/views/content/en/accessibility.md
+++ b/apps/fmr/views/content/en/accessibility.md
@@ -1,5 +1,3 @@
-This accessibility statement applies to the E-visa Error Correction Service form.
-
 This website is run by the Home Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 
 - change colours, contrast levels and fonts


### PR DESCRIPTION
## What? 
Removed  reference to EEC as the accessibility statement is for FMR. 
## Why? 
https://collaboration.homeoffice.gov.uk/jira/browse/FMRF-79
## How? 
## Testing?
## Screenshots (optional)
<img width="2610" height="1656" alt="image" src="https://github.com/user-attachments/assets/063bc3d8-31a0-482e-83af-421a6bb75f7d" />

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
