### PR TITLE
adding request limits to evisa

### DIFF
--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -147,6 +147,8 @@ spec:
             limits:
               memory: 1024Mi
               cpu: 200m
+            requests:
+              memory: 512Mi
           envFrom:
             - configMapRef:
                 {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What? 
This pull request introduces a resource request for memory in the `file-vault-deployment.yml` file to ensure the deployment has guaranteed access to a minimum amount of memory.

Resource configuration update:

* Added a `requests.memory` value of `512Mi` under the container resources section in `kube/file-vault/file-vault-deployment.yml` to specify the amount of memory the container requests.

## Why? 
 To prevent the Filve-vault pod from consuming all the memory within the limits.

## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request
- [x] I have written tests (if relevant)
