### PR TITLE
FMRF-68 - Adding persistent volume storage

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,6 +17,11 @@ environment:
   NON_PROD_AVAILABILITY: Mon-Fri 08:00-23:00 Europe/London
   READY_FOR_TEST_DELAY: 20s
   NOTIFY_STUB: stub
+  REDIS_PERSISTENCE_ENABLED: "false"
+  REDIS_PERSISTENCE_ACCESS_MODES: ReadWriteOnce
+  REDIS_PERSISTENCE_STORAGE_CLASS: gp2-encrypted-eu-west-2b
+  REDIS_PERSISTENCE_EXISTING_CLAIM: ""
+  REDIS_PERSISTENCE_ANNOTATIONS_FILE: ""
 
 include_default_branch: &include_default_branch
   include:
@@ -48,7 +53,7 @@ unit_tests: &unit_tests
     - yarn run test:unit
 
 sonar_scanner: &sonar_scanner
-  pull: if-not-exists
+  pull: always
   image: quay.io/ukhomeofficedigital/sonar-scanner:latest
   commands:
     - sonar-scanner -Dproject.settings=./sonar-project.properties
@@ -305,6 +310,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 1Gi
     commands:
       - bin/deploy.sh $${STG_ENV}
     when:
@@ -353,6 +360,8 @@ steps:
         from_secret: kube_server_prod
       KUBE_TOKEN:
         from_secret: kube_token_prod
+      REDIS_PERSISTENCE_ENABLED: "true"
+      REDIS_PERSISTENCE_SIZE: 5Gi
     commands:
       - bin/deploy.sh $${PROD_ENV}
     when:

--- a/bin/clean_up.sh
+++ b/bin/clean_up.sh
@@ -24,3 +24,10 @@ do
     $kubectl delete configmap "$each"
   fi
 done
+
+for each in $($kubectl get pvc -o jsonpath="{.items[*].metadata.name}");
+do
+  if [[ ${each} == redis-pvc* ]]; then
+    $kubectl delete pvc "$each"
+  fi
+done

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -22,7 +22,7 @@ if [[ $1 == 'tear_down' ]]; then
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
 
   $kd --delete -f kube/configmaps/configmap.yml
-  $kd --delete -f kube/redis -f kube/app
+  $kd --delete -f $redis_runtime_files -f kube/app
   echo "Torn Down Branch - $APP_NAME-$DRONE_SOURCE_BRANCH.internal.branch.sas-notprod.homeoffice.gov.uk"
   exit 0
 fi
@@ -43,11 +43,11 @@ fi
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/redis -f kube/file-vault -f kube/app
+  $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/redis  -f kube/file-vault -f kube/app
+  $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -30,30 +30,13 @@ recreate_redis_pvc_if_image_changed() {
   desired_redis_image=$(grep -m1 '^[[:space:]]*image:' kube/redis/redis-deployment.yml | awk '{print $2}')
 
   if [[ -n "${current_redis_image}" && -n "${desired_redis_image}" && "${current_redis_image}" != "${desired_redis_image}" ]]; then
-    redis_claim_name='redis-pvc'
-    echo "Redis image changed (${current_redis_image} -> ${desired_redis_image}), recreating ${redis_claim_name}"
+    echo "Redis image changed (${current_redis_image} -> ${desired_redis_image}), recycling redis deployment while preserving PVC"
 
     $kubectl delete deployment redis --ignore-not-found=true
 
     while $kubectl get pods -l app=redis --no-headers 2>/dev/null | grep -q .; do
       sleep 2
     done
-
-    $kubectl delete pvc "${redis_claim_name}" --ignore-not-found=true
-
-    wait_count=0
-    while $kubectl get pvc "${redis_claim_name}" >/dev/null 2>&1; do
-      wait_count=$((wait_count + 1))
-      if [[ ${wait_count} -ge 30 ]]; then
-        echo "Timed out waiting for ${redis_claim_name} deletion"
-        exit 1
-      fi
-      sleep 2
-    done
-
-    $kd -f $redis_storage_files
-    $kd -f kube/redis/redis-deployment.yml
-    $kubectl rollout status deployment/redis --timeout=180s
   fi
 }
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,6 +17,46 @@ kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
 
+recreate_redis_pvc_if_image_changed() {
+  if [[ ${REDIS_PERSISTENCE_ENABLED} != true ]]; then
+    return
+  fi
+
+  if [[ -n "${REDIS_PERSISTENCE_EXISTING_CLAIM}" ]]; then
+    return
+  fi
+
+  current_redis_image=$($kubectl get deployment redis -o jsonpath='{.spec.template.spec.containers[?(@.name=="redis")].image}' 2>/dev/null || true)
+  desired_redis_image=$(grep -m1 '^[[:space:]]*image:' kube/redis/redis-deployment.yml | awk '{print $2}')
+
+  if [[ -n "${current_redis_image}" && -n "${desired_redis_image}" && "${current_redis_image}" != "${desired_redis_image}" ]]; then
+    redis_claim_name='redis-pvc'
+    echo "Redis image changed (${current_redis_image} -> ${desired_redis_image}), recreating ${redis_claim_name}"
+
+    $kubectl delete deployment redis --ignore-not-found=true
+
+    while $kubectl get pods -l app=redis --no-headers 2>/dev/null | grep -q .; do
+      sleep 2
+    done
+
+    $kubectl delete pvc "${redis_claim_name}" --ignore-not-found=true
+
+    wait_count=0
+    while $kubectl get pvc "${redis_claim_name}" >/dev/null 2>&1; do
+      wait_count=$((wait_count + 1))
+      if [[ ${wait_count} -ge 30 ]]; then
+        echo "Timed out waiting for ${redis_claim_name} deletion"
+        exit 1
+      fi
+      sleep 2
+    done
+
+    $kd -f $redis_storage_files
+    $kd -f kube/redis/redis-deployment.yml
+    $kubectl rollout status deployment/redis --timeout=180s
+  fi
+}
+
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
   export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
@@ -29,6 +69,7 @@ fi
 
 export KUBE_NAMESPACE=$1
 export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+export kubectl="kubectl --insecure-skip-tls-verify --server=$KUBE_SERVER --namespace=$KUBE_NAMESPACE --token=$KUBE_TOKEN"
 
 if [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   export REDIS_PERSISTENCE_ENABLED=true
@@ -49,6 +90,7 @@ elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml
   $kd -f kube/file-vault -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+  recreate_redis_pvc_if_image_changed
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
@@ -56,6 +98,7 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f $redis_storage_files
   $kd -f $redis_runtime_files -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  recreate_redis_pvc_if_image_changed
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -8,12 +8,22 @@ export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
+export REDIS_PERSISTENCE_ACCESS_MODES=${REDIS_PERSISTENCE_ACCESS_MODES:-ReadWriteOnce}
+export REDIS_PERSISTENCE_STORAGE_CLASS=${REDIS_PERSISTENCE_STORAGE_CLASS:-gp2-encrypted-eu-west-2b}
+export REDIS_PERSISTENCE_EXISTING_CLAIM=${REDIS_PERSISTENCE_EXISTING_CLAIM:-}
+export REDIS_PERSISTENCE_ANNOTATIONS_FILE=${REDIS_PERSISTENCE_ANNOTATIONS_FILE:-}
 
 kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
+redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
+redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
+
+sanitize_branch_name() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | tr '/' '-'
+}
 
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
-  export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
+  export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$(cat /root/.dockersock/branch_name.txt)")
 
   $kd --delete -f kube/configmaps/configmap.yml
   $kd --delete -f kube/redis -f kube/app
@@ -22,7 +32,17 @@ if [[ $1 == 'tear_down' ]]; then
 fi
 
 export KUBE_NAMESPACE=$1
-export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
+export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$DRONE_SOURCE_BRANCH")
+
+if [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=1Gi
+elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
+  export REDIS_PERSISTENCE_ENABLED=true
+  export REDIS_PERSISTENCE_SIZE=5Gi
+else
+  export REDIS_PERSISTENCE_ENABLED=false
+fi
 
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
@@ -37,12 +57,14 @@ elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/app/networkpolicy-internal.yml -f kube/app/ingress-internal.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis  -f kube/file-vault -f kube/app/deployment.yml
+  $kd -f $redis_storage_files
+  $kd -f $redis_runtime_files -f kube/file-vault -f kube/app/deployment.yml
 elif [[ ${KUBE_NAMESPACE} == ${PROD_ENV} ]]; then
   $kd -f kube/configmaps/configmap.yml -f kube/app/service.yml
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/app/networkpolicy-external.yml -f kube/app/ingress-external.yml
-  $kd -f kube/redis -f kube/file-vault -f kube/app/deployment.yml
+  $kd -f $redis_storage_files
+  $kd -f $redis_runtime_files -f kube/file-vault -f kube/app/deployment.yml
 fi
 
 sleep $READY_FOR_TEST_DELAY

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -17,13 +17,9 @@ kd='kd --insecure-skip-tls-verify --timeout 10m --check-interval 10s'
 redis_storage_files='kube/redis/redis-persistent-volume-claim.yml'
 redis_runtime_files='kube/redis/redis-service.yml -f kube/redis/redis-network-policy.yml -f kube/redis/redis-deployment.yml'
 
-sanitize_branch_name() {
-  echo "$1" | tr '[:upper:]' '[:lower:]' | tr '/' '-'
-}
-
 if [[ $1 == 'tear_down' ]]; then
   export KUBE_NAMESPACE=$BRANCH_ENV
-  export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$(cat /root/.dockersock/branch_name.txt)")
+  export DRONE_SOURCE_BRANCH=$(cat /root/.dockersock/branch_name.txt)
 
   $kd --delete -f kube/configmaps/configmap.yml
   $kd --delete -f kube/redis -f kube/app
@@ -32,7 +28,7 @@ if [[ $1 == 'tear_down' ]]; then
 fi
 
 export KUBE_NAMESPACE=$1
-export DRONE_SOURCE_BRANCH=$(sanitize_branch_name "$DRONE_SOURCE_BRANCH")
+export DRONE_SOURCE_BRANCH=$(echo $DRONE_SOURCE_BRANCH | tr '[:upper:]' '[:lower:]' | tr '/' '-')
 
 if [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   export REDIS_PERSISTENCE_ENABLED=true

--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -29,6 +29,9 @@ spec:
         app: redis
         {{ end }}
     spec:
+      securityContext:
+        fsGroup: 994
+        fsGroupChangePolicy: OnRootMismatch
       containers:
         - name: redis
           # redis:v7.0.15
@@ -48,5 +51,19 @@ spec:
               cpu: "100m"
               memory: "200Mi"
       volumes:
+        {{ if and (eq .REDIS_PERSISTENCE_ENABLED "true") (ne .REDIS_PERSISTENCE_EXISTING_CLAIM "") }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .REDIS_PERSISTENCE_EXISTING_CLAIM }}
+        {{ else if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+        - name: data
+          persistentVolumeClaim:
+            {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+            claimName: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+            {{ else }}
+            claimName: redis-pvc
+            {{ end }}
+        {{ else }}
         - name: data
           emptyDir: {}
+        {{ end }}

--- a/kube/redis/redis-persistent-volume-claim.yml
+++ b/kube/redis/redis-persistent-volume-claim.yml
@@ -1,0 +1,23 @@
+{{ if eq .REDIS_PERSISTENCE_ENABLED "true" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
+  name: redis-pvc-{{ .DRONE_SOURCE_BRANCH }}
+  {{ else }}
+  name: redis-pvc
+  {{ end }}
+  {{ if ne .REDIS_PERSISTENCE_ANNOTATIONS_FILE "" }}
+  annotations:
+{{ file .REDIS_PERSISTENCE_ANNOTATIONS_FILE | indent 4 }}
+  {{ end }}
+spec:
+  accessModes:
+    - {{ .REDIS_PERSISTENCE_ACCESS_MODES }}
+  {{ if and (ne .REDIS_PERSISTENCE_STORAGE_CLASS "") (ne .REDIS_PERSISTENCE_STORAGE_CLASS "null") }}
+  storageClassName: {{ .REDIS_PERSISTENCE_STORAGE_CLASS }}
+  {{ end }}
+  resources:
+    requests:
+      storage: {{ .REDIS_PERSISTENCE_SIZE }}
+{{ end }}


### PR DESCRIPTION
## What
This pull request introduces configurable persistent storage support for Redis, primarily by updating deployment templates and CI/CD configuration to enable or disable Redis persistence based on environment variables. It also adds security context settings to the Redis deployment and ensures proper handling of persistent volume claims across different environments.

**Persistent storage configuration for Redis:**

* Added a new template `kube/redis/redis-persistent-volume-claim.yml` to dynamically create a PersistentVolumeClaim for Redis based on environment variables, with support for custom access modes, storage class, size, and annotations.
* Updated `kube/redis/redis-deployment.yml` to mount the appropriate volume for Redis, conditionally using a PersistentVolumeClaim or an `emptyDir` based on the `REDIS_PERSISTENCE_ENABLED` flag and claim settings.

**CI/CD pipeline enhancements:**

* Modified `.drone.yml` to introduce new environment variables for Redis persistence configuration, including toggling persistence, specifying storage class, access modes, and claim details.
* Set `REDIS_PERSISTENCE_ENABLED` and `REDIS_PERSISTENCE_SIZE` for staging and production deployment steps in `.drone.yml`, allowing different storage sizes for each environment. [[1]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R313-R314) [[2]](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R363-R364)

**Security improvements:**

* Added a `securityContext` with `fsGroup` and `fsGroupChangePolicy` to the Redis deployment to ensure proper permissions for mounted volumes.

**Other pipeline tweaks:**

* Changed the `sonar_scanner` step in `.drone.yml` to always pull the latest image, ensuring up-to-date analysis tooling.


## Why? 
PersistentVolume ensures that data (like Redis cache/session state) survives pod restarts, rescheduling, or crashes — without it, everything stored in the container is lost the moment it stops running.

## How? 
Config changes

## Testing?
Restart pods and observe behaviour

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
