### PR TITLE
FMRF-68-PVC correction to ensure redis mounts new pod upon deployment

### DIFF
--- a/kube/redis/redis-deployment.yml
+++ b/kube/redis/redis-deployment.yml
@@ -9,6 +9,8 @@ metadata:
   {{ end }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}


### PR DESCRIPTION
## What?
This pull request introduces a deployment strategy update for the Redis deployment configuration in Kubernetes. The main change is the explicit specification of the deployment strategy to ensure pods are recreated during updates.

**Deployment configuration update:**

* In `kube/redis/redis-deployment.yml`, added a `strategy` section with `type: Recreate` to the deployment spec to ensure that old Redis pods are terminated before new ones are started during updates.
## Why?
## How?
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
