### PR TITLE
HOTFIX: Add back redis deployments to deploy scripts

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -67,11 +67,11 @@ fi
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/file-vault -f kube/redis -f kube/app
+  $kd -f kube/file-vault -f $redis_runtime_files -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/file-vault -f kube/redis -f kube/app
+  $kd -f kube/file-vault -f $redis_runtime_files -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   recreate_redis_pvc_if_image_changed
   $kd -f kube/file-vault/file-vault-ingress.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -67,11 +67,11 @@ fi
 if [[ ${KUBE_NAMESPACE} == ${BRANCH_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps -f kube/certs
-  $kd -f kube/file-vault -f kube/app
+  $kd -f kube/file-vault -f kube/redis -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${UAT_ENV} ]]; then
   $kd -f kube/file-vault/file-vault-ingress.yml
   $kd -f kube/configmaps/configmap.yml
-  $kd -f kube/file-vault -f kube/app
+  $kd -f kube/file-vault -f kube/redis -f kube/app
 elif [[ ${KUBE_NAMESPACE} == ${STG_ENV} ]]; then
   recreate_redis_pvc_if_image_changed
   $kd -f kube/file-vault/file-vault-ingress.yml


### PR DESCRIPTION
## What?

* Recent PVC updates pushed to the master branch accidentally removed the Redis deployment definitions, resulting in Redis not being deployed in both branch and UAT environments.


## Why?

Developers reported form failures accompanied by NGINX error messages.

Investigation showed Redis pods were missing from the Drone CI deployment output and can be noticed in namespace

Drone builds remained green because Redis wasn't included in the branch/UAT deploy scripts, so its absence went undetected.

The Redis deployment entries must be added back to restore expected application behaviour.

## How?

Redis deployments were reintroduced into deploy.sh, ensuring they are deployed before the application services to maintain correct startup order and dependency flow.

## Testing?

* Deployed Redis pod successfully to Branch namespace
* FMRF Form is accessible now

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
